### PR TITLE
Add extensions/resolve to requirefire's custom require.

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -1,0 +1,10 @@
+name: 'Setup test environment'
+description: ''
+inputs: {}
+outputs: {}
+runs:
+    using: "composite"
+    steps:
+    - name: Install dependencies with yarn install
+      shell: bash
+      run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: "Test"
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: ./.github/actions/setup-test-env
+    - name: Test
+      shell: bash
+      run: yarn test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: ./.github/actions/setup-test-env
+    - name: Lint
+      shell: bash
+      run: yarn lint
+
+  build-js:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: ./.github/actions/setup-test-env
+    - name: Build
+      shell: bash
+      run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requirefire",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Harry Brundage",
   "license": "MIT",
   "repository": {

--- a/spec/fixtures/inner_transitive.js
+++ b/spec/fixtures/inner_transitive.js
@@ -1,4 +1,6 @@
 module.exports = {
   name: "inner-transitive",
   now: new Date(),
+  requireKeys: Object.keys(require),
+  outerTransitiveResolve: require.resolve("./outer_transitive"),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,9 @@ const createRequirefire = () => {
               return __oldRequire(path);
 			      }
 			  };
+			  require.extensions = __oldRequire.extensions;
+			  require.resolve = __oldRequire.resolve;
+			  require.cache = module.__requirefire__ ? module.__requirefire__.cache : __oldRequire.cache;
     `;
 
     // Wrap module src inside IIFE so that function declarations do not clash with global variables
@@ -100,6 +103,7 @@ const createRequirefire = () => {
     return requireModule(path, requirier);
   }
 
+  requireModule.cache = cache;
   requirefire.cache = cache;
   return requirefire;
 };


### PR DESCRIPTION
Fixes https://github.com/gadget-inc/requirefire/issues/5

`require` has some attributes that `ts-node` is expecting. This PR adds them, just referencing the ones from the require that we're wrapping.

Questions:
1. Will this break any expectations of requirefire? Does requirefire need to custom wrap these in any way?
    - I don't think so. Looking at how require extensions are used, they focus primarily on a single file, so I don't think any special wrapping is necessary.
2. Should we set any of the other props? Looking at node's docs, there's only `cache` and `main`.