### PR TITLE
Handle linked modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest": "^27.0.6",
     "lodash": "*",
     "prettier": "^2.2.1",
-    "typescript": "^4.3.0"
+    "typescript": "^4.3.0",
+    "linked_module": "link:./spec/fixtures/linked_module"
   }
 }

--- a/spec/fixtures/linked_module/index.js
+++ b/spec/fixtures/linked_module/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    foo: "bar"
+};

--- a/spec/fixtures/outer_linked_module.js
+++ b/spec/fixtures/outer_linked_module.js
@@ -1,0 +1,5 @@
+const linked = require('linked_module');
+
+module.exports = {
+    linked
+};

--- a/spec/requirefire.spec.ts
+++ b/spec/requirefire.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lodash/import-scope */
 /* eslint-disable @typescript-eslint/no-var-requires */
-import requirefire, { Requirefire } from "../src";
 import path from "path";
+import requirefire, { Requirefire } from "../src";
 
 describe("requirefire", () => {
   let _require: Requirefire;
@@ -98,5 +98,13 @@ describe("requirefire", () => {
 
   test("modules without newlines at the end can be required", () => {
     const mod = _require("./fixtures/no-newline");
+  });
+
+  test("aliased modules that resolve to the same module should resolve to the same module if cached", () => {
+    const linked = _require("./fixtures/linked_module");
+    linked.foo = "not foo";
+    const { linked: outerLinked } = _require("./fixtures/outer_linked_module");
+
+    expect(linked).toBe(outerLinked);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,8 @@ const createRequirefire = () => {
     prefix += `
 			  const __oldRequire = require;
 			  require = function(path) {
-			      if (module.__requirefire__ && path.startsWith('.')) {
+            const resolvedPath = __oldRequire.resolve(path);
+			      if (module.__requirefire__ && (path.startsWith('.') || module.__requirefire__.cache[resolvedPath])) {
               return module.__requirefire__(path, module);
 			      } else {
               return __oldRequire(path);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,6 +3511,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+"linked_module@link:./spec/fixtures/linked_module":
+  version "0.0.0"
+  uid ""
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"


### PR DESCRIPTION
I ran into an issue with different instances of a module being returned depending on whether I was importing a module via relative path and an alias (i.e. linked in package.json). The module required using the relative path would use requirefire but using the alias would go through node's require. This meant I wasn't getting the same module. The fix for that is to check if the required module exists in requirefire's cache and if it does return it.