### PR TITLE
Dodge node's require cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "npm": "^10.1.0",
     "prettier": "^2.8.8",
     "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "enhanced-resolve": "^5.15.0",
+    "is-builtin-module": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,16 @@
     "@gadgetinc/prettier-config": "^0.4.0",
     "@swc/core": "^1.3.85",
     "@swc/jest": "^0.2.29",
+    "@types/fs-extra": "^11.0.2",
     "@types/jest": "^29.5.4",
     "@types/node": "^18.15.3",
     "eslint": "^7.32.0",
+    "execa": "^5.1.1",
+    "fs-extra": "^11.1.1",
     "jest": "^29.7.0",
     "linked_module": "link:./spec/fixtures/linked_module",
     "lodash": "*",
+    "npm": "^10.1.0",
     "prettier": "^2.8.8",
     "typescript": "^5.2.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  enhanced-resolve:
+    specifier: ^5.15.0
+    version: 5.15.0
+  is-builtin-module:
+    specifier: ^3.2.1
+    version: 3.2.1
+
 devDependencies:
   '@gadgetinc/eslint-config':
     specifier: ^0.6.1
@@ -17,6 +25,9 @@ devDependencies:
   '@swc/jest':
     specifier: ^0.2.29
     version: 0.2.29(@swc/core@1.3.85)
+  '@types/fs-extra':
+    specifier: ^11.0.2
+    version: 11.0.2
   '@types/jest':
     specifier: ^29.5.4
     version: 29.5.5
@@ -26,6 +37,12 @@ devDependencies:
   eslint:
     specifier: ^7.32.0
     version: 7.32.0
+  execa:
+    specifier: ^5.1.1
+    version: 5.1.1
+  fs-extra:
+    specifier: ^11.1.1
+    version: 11.1.1
   jest:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@18.17.17)
@@ -35,6 +52,9 @@ devDependencies:
   lodash:
     specifier: '*'
     version: 4.17.21
+  npm:
+    specifier: ^10.1.0
+    version: 10.1.0
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
@@ -972,6 +992,13 @@ packages:
       '@babel/types': 7.22.19
     dev: true
 
+  /@types/fs-extra@11.0.2:
+    resolution: {integrity: sha512-c0hrgAOVYr21EX8J0jBMXGLMgJqVf/v6yxi0dLaJboW9aQPh16Id+z6w2Tx1hm+piJOLv8xPfVKZCLfjPw/IMQ==}
+    dependencies:
+      '@types/jsonfile': 6.1.2
+      '@types/node': 18.17.17
+    dev: true
+
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
@@ -1007,6 +1034,12 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/jsonfile@6.1.2:
+    resolution: {integrity: sha512-8t92P+oeW4d/CRQfJaSqEwXujrhH4OEeHRjGU3v1Q8mUS8GPF3yiX26sw4svv6faL2HfBtGTe2xWIoVgN3dy9w==}
+    dependencies:
+      '@types/node': 18.17.17
     dev: true
 
   /@types/node@18.17.17:
@@ -1465,6 +1498,11 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
+  /builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1715,6 +1753,14 @@ packages:
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
+
+  /enhanced-resolve@5.15.0:
+    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+    dev: false
 
   /enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -2260,6 +2306,15 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -2400,7 +2455,6 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -2547,6 +2601,13 @@ packages:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
     dev: true
+
+  /is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: false
 
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -3234,6 +3295,14 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
+  /jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.0
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3401,6 +3470,81 @@ packages:
     dependencies:
       path-key: 3.1.1
     dev: true
+
+  /npm@10.1.0:
+    resolution: {integrity: sha512-pZ2xybXzNGbJFZEKNbPoEXsE38Xou9VTnxxBk+B3pz0ndsGCs7iWHoUCPSsISU2hjmkWfDkJo3bYKE8RDOg4eg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+    dev: true
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/package-json'
+      - '@npmcli/promise-spawn'
+      - '@npmcli/run-script'
+      - '@sigstore/tuf'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - ci-info
+      - cli-columns
+      - cli-table3
+      - columnify
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmhook
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - ms
+      - node-gyp
+      - nopt
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - npmlog
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - semver
+      - ssri
+      - supports-color
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
+      - write-file-atomic
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4020,6 +4164,11 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
+  /tapable@2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -4145,6 +4294,11 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /universalify@2.0.0:
+    resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
+    engines: {node: '>= 10.0.0'}
     dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):

--- a/spec/behaviour-matching.spec.ts
+++ b/spec/behaviour-matching.spec.ts
@@ -1,0 +1,115 @@
+import execa from "execa";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import requirefire from "../src";
+
+describe("requirefire vs require behaviour matching", () => {
+  describe.each([
+    ["require", require],
+    ["requirefire", requirefire()],
+  ])("%s", (name, _require) => {
+    test("should require modules", () => {
+      const a = _require("./fixtures/mod_a");
+      const b = _require("./fixtures/mod_b");
+      expect(a.name).toEqual("a");
+      expect(b.name).toEqual("b");
+    });
+
+    test("the same instance return cached versions of the same module when required twice", () => {
+      const one = _require("./fixtures/mod_a");
+      const two = _require("./fixtures/mod_a");
+      expect(one).toBe(two);
+    });
+
+    test("transitive requires are required through requirefire", () => {
+      jest.isolateModules(() => {
+        const outer = _require("./fixtures/outer_transitive");
+        const inner = _require("./fixtures/inner_transitive");
+        expect(outer.inner.random).toEqual(inner.random);
+      });
+    });
+
+    test("transitive requires have require extensions and resolve", () => {
+      const outer = _require("./fixtures/outer_transitive");
+      expect(outer.inner.requireKeys).toContain("cache");
+      expect(outer.inner.requireKeys).toContain("extensions");
+      expect(outer.inner.requireKeys).toContain("resolve");
+    });
+
+    test("transitive requires can resolve correctly", () => {
+      const outer = _require("./fixtures/outer_transitive");
+      expect(outer.inner.outerTransitiveResolve).toEqual(path.resolve(__dirname, "fixtures/outer_transitive.js"));
+    });
+
+    test("non-existent filepath modules throw a module not found error", () => {
+      try {
+        _require("/tmp/does-not-exist-requirefire-test.js");
+      } catch (error: any) {
+        expect(error).toBeTruthy();
+        expect(error.code).toEqual("MODULE_NOT_FOUND");
+        expect(error.message).toContain("Cannot find module '/tmp/does-not-exist-requirefire-test.js'");
+        return;
+      }
+      // unreachable
+      expect(false).toBe(true);
+    });
+
+    test("non-existent node_modules modules throw a module not found error", () => {
+      try {
+        _require("a-magical-package-that-does-everything");
+      } catch (error: any) {
+        expect(error).toBeTruthy();
+        expect(error.code).toEqual("MODULE_NOT_FOUND");
+        expect(error.message).toContain("Cannot find module 'a-magical-package-that-does-everything'");
+        return;
+      }
+      // unreachable
+      expect(false).toBe(true);
+    });
+
+    test("mutual (circular) requires can be required", () => {
+      const a = _require("./fixtures/mutual_a");
+      const b = _require("./fixtures/mutual_b");
+      expect(a.getB()).toBe(b);
+      expect(b.getA()).toBe(a);
+    });
+
+    test("modules without newlines at the end can be required", () => {
+      _require("./fixtures/no-newline");
+    });
+
+    test("aliased modules that resolve to the same module should resolve to the same module if cached", () => {
+      const linked = _require("./fixtures/linked_module");
+      linked.foo = "not foo";
+      const { linked: outerLinked } = _require("./fixtures/outer_linked_module");
+
+      expect(linked).toBe(outerLinked);
+    });
+
+    test("packages with combo esm/cjs exports configured can be requirefired", async () => {
+      const modDir = fs.mkdtempSync(path.join(os.tmpdir(), "requirefire-"));
+      await fs.rm(modDir, { recursive: true, force: true });
+      await fs.mkdir(modDir);
+
+      await fs.writeFile(path.join(modDir, "index.js"), `module.exports = require('dualexports')`);
+      await fs.writeFile(
+        path.join(modDir, "package.json"),
+        JSON.stringify({
+          name: "parent",
+          version: "0.1.0",
+          dependencies: {
+            dualexports: `file:${path.resolve(path.join(__dirname, "fixtures", "dualexports"))}`,
+          },
+        })
+      );
+
+      await execa("npm", ["install"], { cwd: modDir });
+
+      jest.isolateModules(() => {
+        const mod = _require(modDir);
+        expect(mod.foo).toEqual("bar");
+      });
+    });
+  });
+});

--- a/spec/changing-modules.spec.ts
+++ b/spec/changing-modules.spec.ts
@@ -1,0 +1,65 @@
+import execa from "execa";
+import fs from "fs-extra";
+import Module from "module";
+import os from "os";
+import path from "path";
+import requirefire from "../src";
+
+describe("modules that change in the same process lifetime", () => {
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "requirefire-"));
+  let _require: (mod: string) => any;
+  beforeEach(() => {
+    _require = requirefire();
+  });
+
+  describe.each(["foo", "bar", "baz"])("case %s", (name) => {
+    test("a file with different contents can be returned in a test", async () => {
+      await fs.writeFile(path.join(tmpdir, "index.js"), `module.exports = "${name}";`);
+      const result = _require(path.join(tmpdir, "index.js"));
+      expect(result).toBe(name);
+    });
+  });
+
+  test("a module that changes its main path between versions can be required with each version", async () => {
+    // setup a parent module with a require of our test module
+    const modDir = path.join(os.tmpdir(), "requirefire-test");
+    await fs.rm(modDir, { recursive: true, force: true });
+    await fs.mkdir(modDir);
+    console.log(`running test in ${modDir}`)
+
+    await fs.writeFile(path.join(modDir, "index.js"), `module.exports = require('test-mod');`);
+    await fs.writeFile(path.join(modDir, "package.json"), JSON.stringify({
+      name: "parent",
+      version: "0.1.0",
+      dependencies: {
+        "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v1"))}`
+      }
+    }));
+
+    await execa("npm", ["install"], { cwd: modDir });
+
+    // require the parent module, assert it returns the stuff from mod-v1
+    const parent = _require(modDir);
+    expect(parent.version).toEqual(1)
+
+    // update the parent module to require mod-v2
+    await fs.writeFile(path.join(modDir, "package.json"), JSON.stringify({
+      name: "parent",
+      version: "0.1.0",
+      dependencies: {
+        "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v2"))}`
+      }
+    }));
+
+    await execa("npm", ["install"], { cwd: modDir });
+
+    (Module as any)._pathCache = Object.create(null)
+
+    // create a new require function with a different cache
+    _require = requirefire();
+    // require the parent module, assert it returns the stuff from mod-v1
+    debugger
+    const newParent = _require(modDir);
+    expect(newParent.version).toEqual(2);
+  });
+});

--- a/spec/changing-modules.spec.ts
+++ b/spec/changing-modules.spec.ts
@@ -1,6 +1,5 @@
 import execa from "execa";
 import fs from "fs-extra";
-import Module from "module";
 import os from "os";
 import path from "path";
 import requirefire from "../src";
@@ -13,8 +12,15 @@ describe("modules that change in the same process lifetime", () => {
   });
 
   describe.each(["foo", "bar", "baz"])("case %s", (name) => {
-    test("a file with different contents can be returned in a test", async () => {
+    test("a file with different contents can be required", async () => {
       await fs.writeFile(path.join(tmpdir, "index.js"), `module.exports = "${name}";`);
+      const result = _require(path.join(tmpdir, "index.js"));
+      expect(result).toBe(name);
+    });
+
+    test("a file with different contents can be transitively required", async () => {
+      await fs.writeFile(path.join(tmpdir, "index.js"), `module.exports = require("./content");`);
+      await fs.writeFile(path.join(tmpdir, "content.js"), `module.exports = "${name}";`);
       const result = _require(path.join(tmpdir, "index.js"));
       expect(result).toBe(name);
     });
@@ -25,40 +31,42 @@ describe("modules that change in the same process lifetime", () => {
     const modDir = path.join(os.tmpdir(), "requirefire-test");
     await fs.rm(modDir, { recursive: true, force: true });
     await fs.mkdir(modDir);
-    console.log(`running test in ${modDir}`)
 
     await fs.writeFile(path.join(modDir, "index.js"), `module.exports = require('test-mod');`);
-    await fs.writeFile(path.join(modDir, "package.json"), JSON.stringify({
-      name: "parent",
-      version: "0.1.0",
-      dependencies: {
-        "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v1"))}`
-      }
-    }));
+    await fs.writeFile(
+      path.join(modDir, "package.json"),
+      JSON.stringify({
+        name: "parent",
+        version: "0.1.0",
+        dependencies: {
+          "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v1"))}`,
+        },
+      })
+    );
 
     await execa("npm", ["install"], { cwd: modDir });
 
     // require the parent module, assert it returns the stuff from mod-v1
     const parent = _require(modDir);
-    expect(parent.version).toEqual(1)
+    expect(parent.version).toEqual(1);
 
     // update the parent module to require mod-v2
-    await fs.writeFile(path.join(modDir, "package.json"), JSON.stringify({
-      name: "parent",
-      version: "0.1.0",
-      dependencies: {
-        "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v2"))}`
-      }
-    }));
+    await fs.writeFile(
+      path.join(modDir, "package.json"),
+      JSON.stringify({
+        name: "parent",
+        version: "0.1.0",
+        dependencies: {
+          "test-mod": `file:${path.resolve(path.join(__dirname, "fixtures", "mod-v2"))}`,
+        },
+      })
+    );
 
     await execa("npm", ["install"], { cwd: modDir });
 
-    (Module as any)._pathCache = Object.create(null)
-
     // create a new require function with a different cache
     _require = requirefire();
-    // require the parent module, assert it returns the stuff from mod-v1
-    debugger
+    // require the parent module, assert it returns the stuff from mod-v2
     const newParent = _require(modDir);
     expect(newParent.version).toEqual(2);
   });

--- a/spec/fixtures/dualexports/cjs/index.js
+++ b/spec/fixtures/dualexports/cjs/index.js
@@ -1,0 +1,1 @@
+module.exports.foo = "bar";

--- a/spec/fixtures/dualexports/esm/index.js
+++ b/spec/fixtures/dualexports/esm/index.js
@@ -1,0 +1,1 @@
+export const foo = "bar";

--- a/spec/fixtures/dualexports/package.json
+++ b/spec/fixtures/dualexports/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "subexports",
+  "version": "0.2.0",
+  "main": "dist/main.js",
+  "exports": {
+    ".": {
+      "import": "esm/index.js",
+      "require": "cjs/index.js"
+    }
+  }
+}

--- a/spec/fixtures/inner_transitive.js
+++ b/spec/fixtures/inner_transitive.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: "inner-transitive",
-  now: new Date(),
+  random: Math.random(),
   requireKeys: Object.keys(require),
   outerTransitiveResolve: require.resolve("./outer_transitive"),
 };

--- a/spec/fixtures/mod-v1/index.js
+++ b/spec/fixtures/mod-v1/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  version: 1,
+};

--- a/spec/fixtures/mod-v1/package.json
+++ b/spec/fixtures/mod-v1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mod",
+  "version": "0.1.0",
+  "main": "index.js"
+}

--- a/spec/fixtures/mod-v2/dist/index.js
+++ b/spec/fixtures/mod-v2/dist/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  version: 2,
+};

--- a/spec/fixtures/mod-v2/package.json
+++ b/spec/fixtures/mod-v2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mod",
+  "version": "0.2.0",
+  "main": "dist/index.js"
+}

--- a/spec/fixtures/outer_transitive.js
+++ b/spec/fixtures/outer_transitive.js
@@ -2,6 +2,6 @@ const inner = require("./inner_transitive");
 
 module.exports = {
   name: "inner-transitive",
-  now: new Date(),
+  random: Math.random(),
   inner,
 };

--- a/spec/fixtures/subexports/dist/main.js
+++ b/spec/fixtures/subexports/dist/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+  key: "main",
+};

--- a/spec/fixtures/subexports/dist/sub.js
+++ b/spec/fixtures/subexports/dist/sub.js
@@ -1,0 +1,3 @@
+module.exports = {
+  key: "sub",
+};

--- a/spec/fixtures/subexports/package.json
+++ b/spec/fixtures/subexports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "subexports",
+  "version": "0.2.0",
+  "main": "dist/main.js",
+  "exports": {
+    ".": "./dist/main.js",
+    "./sub": "./dist/sub.js"
+  }
+}

--- a/spec/requirefire.spec.ts
+++ b/spec/requirefire.spec.ts
@@ -1,5 +1,8 @@
 /* eslint-disable lodash/import-scope */
 /* eslint-disable @typescript-eslint/no-var-requires */
+import execa from "execa";
+import fs from "fs-extra";
+import os from "os";
 import path from "path";
 import type { Requirefire } from "../src";
 import requirefire from "../src";
@@ -10,25 +13,12 @@ describe("requirefire", () => {
     _require = requirefire();
   });
 
-  it("should require modules", () => {
-    const a = _require("./fixtures/mod_a");
-    const b = _require("./fixtures/mod_b");
-    expect(a.name).toEqual("a");
-    expect(b.name).toEqual("b");
-  });
-
   it("should not use node's built in require to require modules", () => {
     jest.isolateModules(() => {
       const fired = _require("./fixtures/mod_a");
       const normal = require("./fixtures/mod_a");
       expect(fired).not.toBe(normal);
     });
-  });
-
-  it("the same instance return cached versions of the same module when required twice", () => {
-    const one = _require("./fixtures/mod_a");
-    const two = _require("./fixtures/mod_a");
-    expect(one).toBe(two);
   });
 
   it("the requirefire cache should be clearable", () => {
@@ -50,21 +40,17 @@ describe("requirefire", () => {
   test("transitive requires are required through requirefire", () => {
     jest.isolateModules(() => {
       const outer = _require("./fixtures/outer_transitive");
-      const requiredInner = require("./fixtures/inner_transitive");
-      expect(outer.inner.now).not.toEqual(requiredInner.now);
+      const inner = _require("./fixtures/inner_transitive");
+      expect(outer.inner.random).toEqual(inner.random);
     });
   });
 
-  test("transitive requires have require extensions and resolve", () => {
-    const outer = _require("./fixtures/outer_transitive");
-    expect(outer.inner.requireKeys).toContain("cache");
-    expect(outer.inner.requireKeys).toContain("extensions");
-    expect(outer.inner.requireKeys).toContain("resolve");
-  });
-
-  test("transitive requires can resolve correctly", () => {
-    const outer = _require("./fixtures/outer_transitive");
-    expect(outer.inner.outerTransitiveResolve).toEqual(path.resolve(__dirname, "fixtures/outer_transitive.js"));
+  test("transitive requires are can still be required through normal require", () => {
+    jest.isolateModules(() => {
+      const outer = _require("./fixtures/outer_transitive");
+      const requiredInner = require("./fixtures/inner_transitive");
+      expect(outer.inner.random).not.toEqual(requiredInner.random);
+    });
   });
 
   test("has a cache separate from require", () => {
@@ -73,20 +59,6 @@ describe("requirefire", () => {
     expect(_require.cache).toHaveProperty([path.resolve(__dirname, "./fixtures/inner_transitive.js")]);
     expect(require.cache).not.toHaveProperty([path.resolve(__dirname, "./fixtures/outer_transitive.js")]);
     expect(require.cache).not.toHaveProperty([path.resolve(__dirname, "./fixtures/inner_transitive.js")]);
-  });
-
-  test("mutual (circular) requires can be required", () => {
-    const a = require("./fixtures/mutual_a");
-    const b = require("./fixtures/mutual_b");
-    expect(a.getB()).toBe(b);
-    expect(b.getA()).toBe(a);
-  });
-
-  test("mutual (circular) requires can be requirefired", () => {
-    const a = _require("./fixtures/mutual_a");
-    const b = _require("./fixtures/mutual_b");
-    expect(a.getB()).toBe(b);
-    expect(b.getA()).toBe(a);
   });
 
   test("node modules required by requirefired modules are not themselves requirefired", () => {
@@ -98,7 +70,7 @@ describe("requirefire", () => {
   });
 
   test("modules without newlines at the end can be required", () => {
-    const mod = _require("./fixtures/no-newline");
+    _require("./fixtures/no-newline");
   });
 
   test("aliased modules that resolve to the same module should resolve to the same module if cached", () => {
@@ -107,5 +79,35 @@ describe("requirefire", () => {
     const { linked: outerLinked } = _require("./fixtures/outer_linked_module");
 
     expect(linked).toBe(outerLinked);
+  });
+
+  test("packages with exports configured can be requirefired", async () => {
+    const modDir = fs.mkdtempSync(path.join(os.tmpdir(), "requirefire-"));
+    await fs.rm(modDir, { recursive: true, force: true });
+    await fs.mkdir(modDir);
+
+    await fs.writeFile(
+      path.join(modDir, "index.js"),
+      `module.exports = {
+      main: require('subexports'),
+      sub: require('subexports/sub'),
+    }`
+    );
+    await fs.writeFile(
+      path.join(modDir, "package.json"),
+      JSON.stringify({
+        name: "parent",
+        version: "0.1.0",
+        dependencies: {
+          subexports: `file:${path.resolve(path.join(__dirname, "fixtures", "subexports"))}`,
+        },
+      })
+    );
+
+    await execa("npm", ["install"], { cwd: modDir });
+
+    const mod = _require(modDir);
+    expect(mod.main.key).toEqual("main");
+    expect(mod.sub.key).toEqual("sub");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
+import { ResolverFactory } from "enhanced-resolve";
+import fs from "fs";
+import isBuiltinModule from "is-builtin-module";
 import Module from "module";
+import path from "path";
 
 /**
  * Declares all globals with a var and assigns the global object. Thus you're able to
@@ -51,49 +55,68 @@ const loadModuleWithWrapper = (module: Module, prefix: string, suffix: string) =
     (Module as any).wrapper[1] = moduleWrapper1;
   }
 };
+
 /**
  * Produce a new requirefire instance.
  */
 const createRequirefire = () => {
   const cache: Record<string, Module> = {};
+  const resolver = ResolverFactory.createResolver({
+    useSyncFileSystemCalls: true,
+    fileSystem: fs as any,
+    conditionNames: ["require", "node"],
+    extensions: [".js", ".json", ".node", ...Object.keys(require.extensions)],
+  });
 
-  function requireModule(targetPath: string, parentModule?: Module) {
-    if (typeof targetPath !== "string") {
+  function requireModule(request: string, parentModule?: Module) {
+    if (typeof request !== "string") {
       throw new TypeError("Filename must be a string");
     }
 
+    if (isBuiltinModule(request)) {
+      return require(request);
+    }
+
     // Resolve full filename relative to the parent module
-    targetPath = (Module as any)._resolveFilename(targetPath, parentModule);
-    if (cache[targetPath]) {
-      const existingModule = cache[targetPath];
+    let actualPath: string;
+    try {
+      actualPath = resolver.resolveSync({}, parentModule ? path.dirname(parentModule.filename) : ".", request) as string;
+    } catch (error: any) {
+      const err = new Error(`Cannot find module '${request}'. Note: Using requirefire. Resolution error: ${error.message}`) as any;
+      err.code = "MODULE_NOT_FOUND";
+      throw err;
+    }
+
+    if (cache[actualPath]) {
+      const existingModule = cache[actualPath];
       return existingModule.exports;
     }
 
     // Create testModule as it would be created by require()
-    const targetModule = new Module(targetPath, parentModule);
-    cache[targetPath] = targetModule;
-
-    // We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
-    let prefix = getImportGlobalsSrc();
+    const targetModule = new Module(actualPath, parentModule);
+    cache[actualPath] = targetModule;
 
     // Intercept require calls when evaluating the inner module to use requirefire
     (targetModule as any).__requirefire__ = requireModule;
     (targetModule as any).__requirefire_process = process;
 
+    // We prepend a list of all globals declared with var so they can be overridden (without changing original globals)
+    let prefix = getImportGlobalsSrc();
     prefix += `
-			  const __oldRequire = require;
-			  require = function(path) {
-            const resolvedPath = __oldRequire.resolve(path);
-			      if (module.__requirefire__ && (path.startsWith('.') || module.__requirefire__.cache[resolvedPath])) {
-              return module.__requirefire__(path, module);
-			      } else {
-              return __oldRequire(path);
-			      }
-			  };
-			  require.extensions = __oldRequire.extensions;
-			  require.resolve = __oldRequire.resolve;
-			  require.cache = module.__requirefire__ ? module.__requirefire__.cache : __oldRequire.cache;
-        var process = module.__requirefire_process ? module.__requirefire_process : global.process;
+      const __oldRequire = require;
+
+      require = function(path) {
+        if (module.__requirefire__) {
+          return module.__requirefire__(path, module);
+        }
+
+        return __oldRequire(path);
+      };
+
+      require.extensions = __oldRequire.extensions;
+      require.resolve = __oldRequire.resolve;
+      require.cache = module.__requirefire__ ? module.__requirefire__.cache : __oldRequire.cache;
+      var process = module.__requirefire_process ? module.__requirefire_process : global.process;
     `;
 
     // Wrap module src inside IIFE so that function declarations do not clash with global variables


### PR DESCRIPTION
requirefire intentionally re-creates the entire require stack such that when used, its as if the returned `require` function is from a totally different process. Two requirefire instances should be totally independent, with different require caches. Crucially, if the files on disk change between the creation of one instance and the next, the second instance should reflect those changes.

Before this change, that wasn't the case in a particular circumstance that burned us in Gadget. Specifically, if a module was required by require fire, and that module required another module from it's node_modules directory, subsequent requirefire instances requiring the entrypoint module will always get the same copy of the node_modules module, regardless of if it changes.

An example:

 - const a = requirefire();
 - a("foo") requires "@gadgetinc/api-client-core" from foo's node_modules, gets one copy of api-client-core
 - we change api-client-core in the node_modules on disk
 - const b = requirefire();
 - b("foo") requires "@gadgetinc/api-client-core" again, should return the new copy, but didn't.

The reason the old copy was returned by new instances of requirefire is that there was another cache inside the node internals that all requirefire instances were sharing by accident: `Module._pathCache`.

The path cache is used by node to cache resolutions from entrypoints to files on disk. Usually in node the path cache is only ever filled and never emptied, and thus node will never pick up new or changed resolutions after the first time they are run. We explicitly want the opposite with requirefire, so we need to change to using one path cache per requirefire instance instead of one shared one.

Super regrettably, this shared global cache is baked in deep to node. I couldn't figure out any way to re-use node's internal logic while still changing the semantics of which path cache is used, so I had to skip node's resolve stuff that uses that cache entirely. Luckly, there's a great userland re-implementation of resolving in webpack that we can use, that has great support for ... everything. As webpack would need!