### PR TITLE
Use Module._extensions instead of require.extensions for Jest compatability

### DIFF
--- a/spec/requirefire.spec.ts
+++ b/spec/requirefire.spec.ts
@@ -111,6 +111,14 @@ describe("requirefire", () => {
     expect(mod.sub.key).toEqual("sub");
   });
 
+  test("require.extensions reflects Module._extensions even when jest patches it", () => {
+    const Module = require("module");
+    const moduleExtensions = Object.keys(Module._extensions);
+    // Jest patches require.extensions to {}, but requirefire should still pick up the real extensions
+    expect(Object.keys(require.extensions)).toEqual([]);
+    expect(moduleExtensions).toEqual(expect.arrayContaining([".js", ".json", ".node"]));
+  });
+
   test("instances can be passed the parent module for resolving relative paths", () => {
     _require = requirefire(module);
 
@@ -121,5 +129,5 @@ describe("requirefire", () => {
     const two = _require("./fixtures/mod_a");
     expect(one).not.toBe(two);
     expect(one.name).toEqual(two.name);
-  })
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ const loadModuleWithWrapper = (module: Module, prefix: string, suffix: string) =
 
 /**
  * Produce a new requirefire instance.
- * 
+ *
  * @param contextModule The module that will be used as the parent module for the requirefire instance. Relative paths will be resolved relative to this module.
  */
 const createRequirefire = (contextModule?: Module) => {
@@ -71,7 +71,7 @@ const createRequirefire = (contextModule?: Module) => {
     useSyncFileSystemCalls: true,
     fileSystem: fs as any,
     conditionNames: ["require", "node"],
-    extensions: [".js", ".json", ".node", ...Object.keys(require.extensions)],
+    extensions: [".js", ".json", ".node", ...Object.keys((Module as any)._extensions)],
   });
 
   function requireModule(request: string, parentModule?: Module) {


### PR DESCRIPTION
Jest patches require.extensions to an empty object, which caused the resolver to miss file extensions. Module._extensions is the canonical source that Jest doesn't touch.